### PR TITLE
fix(fix): disambiguate malformed frames from incomplete messages in FIX parser

### DIFF
--- a/crates/fix/Cargo.toml
+++ b/crates/fix/Cargo.toml
@@ -11,7 +11,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-tokio = { version = "1", features = ["net", "io-util", "sync", "time"] }
+tokio = { version = "1", features = ["net", "io-util", "sync", "time", "macros"] }
 tracing = "0.1"
 chrono = "0.4"
 thiserror = "1.0"

--- a/crates/fix/src/lib.rs
+++ b/crates/fix/src/lib.rs
@@ -22,6 +22,20 @@ pub enum FixError {
     Parse(String),
     #[error("Checksum mismatch: expected {expected}, got {actual}")]
     ChecksumMismatch { expected: u8, actual: u8 },
+    /// Tag 9 (BodyLength) framing is inconsistent with the bytes actually
+    /// present: the declared length lands inside the buffer but does not
+    /// point at the CheckSum field. (Distinct from "not enough bytes yet",
+    /// which is `Ok(None)`, not an error.)
+    #[error("BodyLength framing error: {0}")]
+    BodyLengthFraming(String),
+    /// The frame's CheckSum field (tag 10) is missing where BodyLength said
+    /// it would be, or is not a parseable numeric value.
+    #[error("missing or malformed CheckSum field: {0}")]
+    MissingChecksumField(String),
+    /// Catch-all for a structurally malformed frame at the current `8=`
+    /// start (e.g. no `9=` after `8=`, non-numeric BodyLength).
+    #[error("malformed FIX frame: {reason}")]
+    MalformedFrame { reason: String },
 }
 
 pub mod serializer {
@@ -78,6 +92,7 @@ pub mod serializer {
         }
     }
 
+    #[derive(Debug)]
     pub struct FixMessage {
         msg_type: MsgType,
         fields: std::collections::HashMap<u32, String>,
@@ -225,6 +240,22 @@ pub mod serializer {
 
         /// Extract the next complete FIX message from the buffer.
         ///
+        /// Three-way result — the whole point of this signature is to *not*
+        /// conflate "wait for more bytes" with "this frame is garbage":
+        ///   * `Ok(Some(msg))` — a complete, checksum-valid message was parsed
+        ///     and consumed from the buffer.
+        ///   * `Ok(None)`      — not enough bytes yet (including: tag 9's
+        ///     declared BodyLength runs past what's buffered). Buffer is left
+        ///     untouched; call again after more bytes arrive.
+        ///   * `Err(..)`       — the frame at the current `8=` start is
+        ///     malformed (bad BodyLength framing, missing/bad CheckSum, bad
+        ///     checksum value). Before returning, the parser **resynchronizes**:
+        ///     it discards exactly the corrupt frame and leaves any bytes that
+        ///     follow it intact, so a subsequent valid message in the same TCP
+        ///     read is still recoverable on the next call. This is the
+        ///     "recover-open" invariant: one bad frame must not desync the
+        ///     stream or silently swallow good messages behind it.
+        ///
         /// Algorithm:
         ///   1. Find "8=" prefix (BeginString start)
         ///   2. Find "9=<BodyLength>" field
@@ -232,57 +263,130 @@ pub mod serializer {
         ///   4. Expect "10=<checksum>" immediately after
         ///   5. Validate checksum
         ///   6. Parse all tag=value pairs
-        pub fn next_message(&mut self) -> Option<FixMessage> {
-            // We need at minimum "8=FIX.X.X\x019=N\x0135=X\x0110=XXX\x01"
+        pub fn next_message(&mut self) -> Result<Option<FixMessage>, FixError> {
+            // We need at minimum "8=FIX.X.X\x019=N\x0135=X\x0110=XXX\x01".
+            // Too few bytes to even hold a header => definitely incomplete.
             if self.buffer.len() < 20 {
-                return None;
+                return Ok(None);
             }
 
-            // Step 1: Find start of message (tag 8)
-            let msg_start = self.find_tag_start(8)?;
+            // Step 1: Find start of message (tag 8). No `8=` anywhere yet =>
+            // nothing actionable; treat as incomplete (more bytes may bring
+            // the start of a frame).
+            let msg_start = match self.find_tag_start(8) {
+                Some(s) => s,
+                None => return Ok(None),
+            };
 
-            // Step 2: Find BodyLength (tag 9)
-            let tag9_start = self.find_tag_in_range(9, msg_start)?;
-            let tag9_val_start = self.skip_past_equals(tag9_start)?;
-            let tag9_soh = self.find_soh_after(tag9_val_start)?;
+            // Step 2: Find BodyLength (tag 9). It must appear after `8=`.
+            // If there's no `9=` but there *is* a later `8=`, the current
+            // frame's header is structurally broken => malformed, resync.
+            let tag9_start = match self.find_tag_in_range(9, msg_start) {
+                Some(s) => s,
+                None => {
+                    return self.fail_resync(
+                        msg_start,
+                        FixError::MalformedFrame {
+                            reason: "no BodyLength (tag 9) after BeginString".to_string(),
+                        },
+                    );
+                }
+            };
+            // We just located `9=`; the `=` and a following SOH must exist.
+            let tag9_val_start = match self.skip_past_equals(tag9_start) {
+                Some(p) => p,
+                // `9` with no `=` yet — could still be mid-write of the field.
+                None => return Ok(None),
+            };
+            let tag9_soh = match self.find_soh_after(tag9_val_start) {
+                Some(p) => p,
+                // BodyLength value not terminated yet — incomplete.
+                None => return Ok(None),
+            };
 
-            let body_len_str = std::str::from_utf8(&self.buffer[tag9_val_start..tag9_soh]).ok()?;
-            let body_length: usize = body_len_str.parse().ok()?;
+            let body_len_str = match std::str::from_utf8(&self.buffer[tag9_val_start..tag9_soh]) {
+                Ok(s) => s,
+                Err(_) => {
+                    return self.fail_resync(
+                        msg_start,
+                        FixError::BodyLengthFraming(
+                            "BodyLength field is not valid UTF-8".to_string(),
+                        ),
+                    );
+                }
+            };
+            let body_length: usize = match body_len_str.parse() {
+                Ok(n) => n,
+                Err(_) => {
+                    return self.fail_resync(
+                        msg_start,
+                        FixError::BodyLengthFraming(format!(
+                            "BodyLength is not a number: {body_len_str:?}"
+                        )),
+                    );
+                }
+            };
 
             // Step 3: Body starts after "9=N\x01"
             let body_start = tag9_soh + 1;
             let body_end = body_start + body_length;
 
-            // Do we have enough bytes? body + "10=XXX\x01" (minimum 8 bytes)
-            if self.buffer.len() < body_end + 7 {
-                return None; // incomplete message, wait for more bytes
+            // Do we have enough bytes? body + at least "10=N\x01" (5 bytes).
+            // If not, this is *incomplete*, NOT malformed — the declared body
+            // simply hasn't fully arrived. Preserve the buffer and wait.
+            if self.buffer.len() < body_end + 5 {
+                return Ok(None);
             }
 
-            // Step 4: Find checksum field "10=" after body
+            // Step 4: BodyLength is supposed to land us exactly on "10=".
+            // If it doesn't, the framing is wrong: BodyLength under/over-counts
+            // and the CheckSum tag isn't where it claimed to be.
             let checksum_region_start = body_end;
-            if checksum_region_start + 7 > self.buffer.len() {
-                return None;
-            }
-
-            // Expect "10=" at body_end
             if self
                 .buffer
                 .get(checksum_region_start..checksum_region_start + 3)
                 != Some(b"10=")
             {
-                // Malformed — skip this message start and try again
-                self.buffer.drain(..=msg_start);
-                return None;
+                return self.fail_resync(
+                    msg_start,
+                    FixError::BodyLengthFraming(format!(
+                        "BodyLength={body_length} does not point at the CheckSum field (no `10=` there)"
+                    )),
+                );
             }
 
             let cs_val_start = checksum_region_start + 3;
-            let cs_soh = self.find_soh_after(cs_val_start)?;
+            let cs_soh = match self.find_soh_after(cs_val_start) {
+                Some(p) => p,
+                // We saw `10=` but its value isn't SOH-terminated yet.
+                None => return Ok(None),
+            };
             let msg_end = cs_soh + 1;
 
             // Step 5: Validate checksum
             let expected_checksum_str =
-                std::str::from_utf8(&self.buffer[cs_val_start..cs_soh]).ok()?;
-            let expected_checksum: u8 = expected_checksum_str.parse().ok()?;
+                match std::str::from_utf8(&self.buffer[cs_val_start..cs_soh]) {
+                    Ok(s) => s,
+                    Err(_) => {
+                        return self.fail_resync(
+                            msg_start,
+                            FixError::MissingChecksumField(
+                                "CheckSum value is not valid UTF-8".to_string(),
+                            ),
+                        );
+                    }
+                };
+            let expected_checksum: u8 = match expected_checksum_str.parse() {
+                Ok(n) => n,
+                Err(_) => {
+                    return self.fail_resync(
+                        msg_start,
+                        FixError::MissingChecksumField(format!(
+                            "CheckSum is not a number: {expected_checksum_str:?}"
+                        )),
+                    );
+                }
+            };
 
             let actual_checksum: u8 = {
                 let sum: u32 = self.buffer[msg_start..checksum_region_start]
@@ -293,16 +397,62 @@ pub mod serializer {
             };
 
             if expected_checksum != actual_checksum {
-                // Malformed checksum - drain up to msg_end to continue
-                self.buffer.drain(..msg_end);
-                return None;
+                return self.fail_resync(
+                    msg_start,
+                    FixError::ChecksumMismatch {
+                        expected: expected_checksum,
+                        actual: actual_checksum,
+                    },
+                );
             }
 
-            // Step 6: Extract the full message bytes and parse
+            // Step 6: Extract the full message bytes and parse. Note we drop
+            // any leading garbage before `msg_start` here too (the bytes
+            // before the `8=` we locked onto).
             let msg_bytes: Vec<u8> = self.buffer.drain(..msg_end).collect();
+            let msg_bytes = &msg_bytes[msg_start..];
 
-            // Parse all tag-value pairs from the entire message
-            FixMessage::from_tag_values(&msg_bytes).ok()
+            // Parse all tag-value pairs from the message body. A failure here
+            // is a *field-level* parse error (bad tag, bad UTF-8 in a value)
+            // on an otherwise well-framed, checksum-valid frame — that frame is
+            // already consumed, so we just surface the error; the next call
+            // resumes cleanly from whatever follows.
+            FixMessage::from_tag_values(msg_bytes).map(Some)
+        }
+
+        /// Discard the corrupt frame starting at `bad_start` and resynchronize:
+        /// scan forward for the next plausible `8=` (either at buffer start or
+        /// immediately after a SOH) and drop everything before it. If no further
+        /// `8=` exists, drain the whole buffer. Returns the supplied error.
+        ///
+        /// This is what makes a single malformed frame *non-fatal*: bytes that
+        /// belong to the next, well-formed message survive the drain.
+        fn fail_resync(
+            &mut self,
+            bad_start: usize,
+            err: FixError,
+        ) -> Result<Option<FixMessage>, FixError> {
+            // Look for the next "8=" strictly after the bad frame's start.
+            let mut resync_at = None;
+            let search_from = bad_start + 1;
+            let mut i = search_from;
+            while i + 2 <= self.buffer.len() {
+                let at_boundary = i == 0 || self.buffer[i - 1] == 0x01;
+                if at_boundary && self.buffer[i..].starts_with(b"8=") {
+                    resync_at = Some(i);
+                    break;
+                }
+                i += 1;
+            }
+            match resync_at {
+                Some(pos) => {
+                    self.buffer.drain(..pos);
+                }
+                None => {
+                    self.buffer.clear();
+                }
+            }
+            Err(err)
         }
 
         // ── Helper methods ───────────────────────────────────────
@@ -362,15 +512,61 @@ pub mod serializer {
     mod tests {
         use super::*;
 
-        /// Build a valid FIX message from tag-value pairs.
+        /// Build a valid FIX message from tag-value pairs (correct BodyLength
+        /// and CheckSum, courtesy of `encode()`).
         fn build_fix_message(fields: &[(u32, &str)]) -> Vec<u8> {
             let mut m = FixMessage::new(MsgType::Unknown);
             for (tag, val) in fields {
                 m.set_field(*tag, val);
             }
-            // Use encode() which correctly computes BodyLength and Checksum
             m.encode()
         }
+
+        /// A small, always-valid heartbeat we can append after a corrupt frame
+        /// to prove resync recovered it.
+        fn good_heartbeat() -> Vec<u8> {
+            build_fix_message(&[(8, "FIX.4.4"), (35, "0"), (49, "A"), (56, "B"), (34, "99")])
+        }
+
+        /// Hand-build a frame from *exactly* the given body fields (no auto
+        /// MsgType injection, unlike `FixMessage::encode()`), with a correct
+        /// BodyLength and CheckSum. Lets us construct a wire-valid frame that
+        /// genuinely lacks tag 35.
+        ///
+        /// `begin_string` becomes `8=...`, then `9=<len>`, then the body, then
+        /// `10=<sum>`. BodyLength counts the bytes after the `9=N\x01` field up
+        /// to and including the SOH before `10=` (i.e. the body part).
+        fn build_raw_frame(begin_string: &str, body_fields: &[(u32, &str)]) -> Vec<u8> {
+            let mut body = String::new();
+            for (tag, val) in body_fields {
+                body.push_str(&format!("{tag}={val}\x01"));
+            }
+            let mut out = String::new();
+            out.push_str(&format!("8={begin_string}\x01"));
+            out.push_str(&format!("9={}\x01", body.len()));
+            out.push_str(&body);
+            let sum: u32 = out.as_bytes().iter().map(|b| *b as u32).sum();
+            out.push_str(&format!("10={:03}\x01", (sum % 256) as u8));
+            out.into_bytes()
+        }
+
+        /// Rewrite the value of the first SOH-delimited `9=...` field in an
+        /// otherwise-valid encoded frame, *without* recomputing the checksum.
+        /// Used to manufacture BodyLength-framing corruption.
+        fn corrupt_body_length(frame: &[u8], new_len: &str) -> Vec<u8> {
+            let s = std::str::from_utf8(frame).unwrap();
+            let nine = s.find("\x019=").map(|i| i + 1).unwrap();
+            let val_start = nine + 2; // past "9="
+            let soh = s[val_start..].find('\x01').unwrap() + val_start;
+            let mut out = Vec::new();
+            out.extend_from_slice(&frame[..val_start]);
+            out.extend_from_slice(new_len.as_bytes());
+            out.extend_from_slice(&frame[soh..]);
+            out
+        }
+
+        // ── Happy-path / pre-existing behavior (call sites updated for the
+        //    new `Result<Option<_>, _>` signature) ──────────────────────────
 
         #[test]
         fn test_parse_logon_message() {
@@ -386,7 +582,10 @@ pub mod serializer {
 
             let mut parser = FixParser::new();
             parser.push_bytes(&raw);
-            let msg = parser.next_message().expect("Should parse Logon");
+            let msg = parser
+                .next_message()
+                .expect("well-formed frame must not error")
+                .expect("buffer holds a complete message");
 
             assert_eq!(msg.msg_type(), MsgType::Logon);
             assert_eq!(msg.get_field(49).map(|s| s.as_str()), Some("CLIENT"));
@@ -413,7 +612,10 @@ pub mod serializer {
 
             let mut parser = FixParser::new();
             parser.push_bytes(&raw);
-            let msg = parser.next_message().expect("Should parse ExecReport");
+            let msg = parser
+                .next_message()
+                .expect("well-formed frame must not error")
+                .expect("buffer holds a complete message");
 
             assert_eq!(msg.msg_type(), MsgType::ExecutionReport);
             assert_eq!(msg.get_field(55).map(|s| s.as_str()), Some("AAPL"));
@@ -432,29 +634,11 @@ pub mod serializer {
             parser.push_bytes(&msg1);
             parser.push_bytes(&msg2);
 
-            let parsed1 = parser.next_message().expect("Should get first message");
+            let parsed1 = parser.next_message().unwrap().expect("first message");
             assert_eq!(parsed1.msg_type(), MsgType::Heartbeat);
 
-            let parsed2 = parser.next_message().expect("Should get second message");
+            let parsed2 = parser.next_message().unwrap().expect("second message");
             assert_eq!(parsed2.msg_type(), MsgType::Logout);
-        }
-
-        #[test]
-        fn test_incomplete_message_returns_none() {
-            let raw =
-                build_fix_message(&[(8, "FIX.4.4"), (35, "0"), (49, "A"), (56, "B"), (34, "1")]);
-
-            let mut parser = FixParser::new();
-            // Push only half the bytes
-            parser.push_bytes(&raw[..raw.len() / 2]);
-            assert!(
-                parser.next_message().is_none(),
-                "Incomplete should return None"
-            );
-
-            // Push the rest
-            parser.push_bytes(&raw[raw.len() / 2..]);
-            assert!(parser.next_message().is_some(), "Complete should parse");
         }
 
         #[test]
@@ -472,7 +656,10 @@ pub mod serializer {
 
             let mut parser = FixParser::new();
             parser.push_bytes(&encoded);
-            let decoded = parser.next_message().expect("Roundtrip should work");
+            let decoded = parser
+                .next_message()
+                .expect("roundtrip frame must not error")
+                .expect("roundtrip frame is complete");
 
             assert_eq!(decoded.msg_type(), MsgType::NewOrderSingle);
             assert_eq!(decoded.get_field(55).map(|s| s.as_str()), Some("RELIANCE"));
@@ -482,8 +669,306 @@ pub mod serializer {
 
         #[test]
         fn test_empty_buffer_returns_none() {
+            // WHY: an empty buffer is "wait for more bytes", never an error.
             let mut parser = FixParser::new();
-            assert!(parser.next_message().is_none());
+            assert!(matches!(parser.next_message(), Ok(None)));
+        }
+
+        // ── Regression: incomplete vs malformed must NOT be conflated ───────
+
+        #[test]
+        fn test_incomplete_message_returns_none() {
+            // WHY: a truncated TCP read is normal; the parser must report
+            // `Ok(None)` and leave the buffer untouched so the rest of the
+            // frame can be appended and parsed on a later call. Regressing
+            // this back to "drain + None" (or, worse, `Err`) would either lose
+            // the message or kill the session over a non-event.
+            let raw =
+                build_fix_message(&[(8, "FIX.4.4"), (35, "0"), (49, "A"), (56, "B"), (34, "1")]);
+
+            let mut parser = FixParser::new();
+            parser.push_bytes(&raw[..raw.len() / 2]);
+            assert!(
+                matches!(parser.next_message(), Ok(None)),
+                "half a frame is incomplete, not malformed"
+            );
+
+            // Now complete the frame; the *same* parser must parse it.
+            parser.push_bytes(&raw[raw.len() / 2..]);
+            let msg = parser
+                .next_message()
+                .expect("completed frame must not error")
+                .expect("completed frame is now whole");
+            assert_eq!(msg.msg_type(), MsgType::Heartbeat);
+        }
+
+        #[test]
+        fn test_body_length_exceeds_buffer_is_incomplete_not_malformed() {
+            // WHY: tag 9 saying "200 more bytes" when only 40 are buffered is
+            // the textbook *incomplete* case — the body just hasn't arrived.
+            // It MUST be `Ok(None)` (preserve the buffer), never `Err`. If we
+            // returned `Err` here a peer that simply writes a large message in
+            // two TCP segments would have its session torn down.
+            let frame =
+                build_fix_message(&[(8, "FIX.4.4"), (35, "0"), (49, "A"), (56, "B"), (34, "1")]);
+            // Inflate BodyLength far past what's buffered.
+            let lying = corrupt_body_length(&frame, "9999");
+
+            let mut parser = FixParser::new();
+            parser.push_bytes(&lying);
+            assert!(
+                matches!(parser.next_message(), Ok(None)),
+                "BodyLength > buffered bytes is incomplete"
+            );
+        }
+
+        #[test]
+        fn test_truncated_then_completed_roundtrips() {
+            // WHY: same as the incomplete-message test but split at an
+            // adversarial spot (one byte before the closing SOH) — proves the
+            // buffer is genuinely preserved across calls, not just "close
+            // enough".
+            let frame =
+                build_fix_message(&[(8, "FIX.4.4"), (35, "8"), (49, "EX"), (56, "AL"), (34, "7")]);
+            let cut = frame.len() - 1;
+
+            let mut parser = FixParser::new();
+            parser.push_bytes(&frame[..cut]);
+            assert!(matches!(parser.next_message(), Ok(None)));
+            parser.push_bytes(&frame[cut..]);
+            let msg = parser.next_message().unwrap().expect("now complete");
+            assert_eq!(msg.msg_type(), MsgType::ExecutionReport);
+        }
+
+        // ── Malformed framing → Err + resync (recover-open) ────────────────
+
+        #[test]
+        fn test_body_length_too_short_errs_and_resyncs() {
+            // WHY: this is the stream-desync hazard the PR exists to kill. A
+            // garbled BodyLength on frame A used to make the parser drain the
+            // whole buffer and return `None`, *silently eating* a perfectly
+            // good frame B that arrived in the same TCP read. Now: frame A is
+            // an `Err`, the parser resyncs to frame B's `8=`, and the very next
+            // call returns frame B. No data loss.
+            let mut bad =
+                build_fix_message(&[(8, "FIX.4.4"), (35, "5"), (49, "A"), (56, "B"), (34, "1")]);
+            bad = corrupt_body_length(&bad, "3"); // far too small → `10=` not at body_end
+            let good = good_heartbeat();
+
+            let mut parser = FixParser::new();
+            parser.push_bytes(&bad);
+            parser.push_bytes(&good);
+
+            let err = parser.next_message().expect_err("frame A is malformed");
+            assert!(matches!(err, FixError::BodyLengthFraming(_)));
+
+            let recovered = parser
+                .next_message()
+                .expect("frame B is well-formed")
+                .expect("frame B was recovered after resync");
+            assert_eq!(recovered.msg_type(), MsgType::Heartbeat);
+            assert_eq!(recovered.get_field(34).map(|s| s.as_str()), Some("99"));
+        }
+
+        #[test]
+        fn test_body_length_lands_but_no_checksum_there_errs_and_resyncs() {
+            // WHY: BodyLength can also over-count and land *inside* a field
+            // instead of on `10=`. Same failure class, same recovery contract.
+            let mut bad =
+                build_fix_message(&[(8, "FIX.4.4"), (35, "0"), (49, "AA"), (56, "BB"), (34, "2")]);
+            // Push BodyLength out by a couple of bytes so body_end falls in the
+            // middle of the trailing field rather than on `10=`.
+            let real_len: usize = {
+                let s = std::str::from_utf8(&bad).unwrap();
+                let n = s.find("\x019=").map(|i| i + 3).unwrap();
+                let soh = s[n..].find('\x01').unwrap() + n;
+                s[n..soh].parse().unwrap()
+            };
+            bad = corrupt_body_length(&bad, &(real_len + 2).to_string());
+            let good = good_heartbeat();
+
+            let mut parser = FixParser::new();
+            parser.push_bytes(&bad);
+            parser.push_bytes(&good);
+
+            let err = parser.next_message().expect_err("no `10=` at declared body_end");
+            assert!(matches!(err, FixError::BodyLengthFraming(_)));
+
+            let recovered = parser.next_message().unwrap().expect("resynced to frame B");
+            assert_eq!(recovered.msg_type(), MsgType::Heartbeat);
+        }
+
+        // ── Checksum failures → Err + resync ───────────────────────────────
+
+        #[test]
+        fn test_invalid_checksum_value_errs_and_resyncs() {
+            // WHY: a checksum mismatch means line corruption (or a buggy peer).
+            // The frame is unusable, but the bytes *after* it might be a clean
+            // message — so it's `Err(ChecksumMismatch)` + resync, not a buffer
+            // wipe. Pre-fix this drained to msg_end and returned `None`, which
+            // happened to keep the next frame, but the caller couldn't tell a
+            // corruption event from "nothing to do yet".
+            //
+            // Construction: take a valid frame and mutate a single body byte by
+            // +1 (length unchanged → framing still fine), leaving tag 10 stale.
+            // The real sum is now off by exactly 1 (mod 256) → guaranteed
+            // mismatch, no flakiness.
+            let mut bad =
+                build_fix_message(&[(8, "FIX.4.4"), (35, "8"), (49, "X"), (56, "Y"), (34, "3")]);
+            let pos = {
+                let s = std::str::from_utf8(&bad).unwrap();
+                s.find("49=X").map(|i| i + 3).unwrap()
+            };
+            bad[pos] = b'Y'; // 'X' (0x58) -> 'Y' (0x59): sum shifts by 1
+            let good = good_heartbeat();
+
+            let mut parser = FixParser::new();
+            parser.push_bytes(&bad);
+            parser.push_bytes(&good);
+
+            let err = parser.next_message().expect_err("checksum is wrong");
+            assert!(matches!(err, FixError::ChecksumMismatch { .. }));
+
+            let recovered = parser.next_message().unwrap().expect("resynced to frame B");
+            assert_eq!(recovered.msg_type(), MsgType::Heartbeat);
+        }
+
+        #[test]
+        fn test_non_numeric_checksum_errs() {
+            // WHY: `10=ABC\x01` is structurally broken — there's no integer to
+            // compare against. Must surface as a structured error
+            // (`MissingChecksumField`), never a panic on `.parse()`.
+            let mut bad =
+                build_fix_message(&[(8, "FIX.4.4"), (35, "0"), (49, "P"), (56, "Q"), (34, "4")]);
+            let s = std::str::from_utf8(&bad).unwrap();
+            let ten = s.rfind("\x0110=").map(|i| i + 4).unwrap();
+            bad[ten] = b'A';
+            bad[ten + 1] = b'B';
+            bad[ten + 2] = b'C';
+
+            let mut parser = FixParser::new();
+            parser.push_bytes(&bad);
+            let err = parser.next_message().expect_err("non-numeric checksum");
+            assert!(matches!(err, FixError::MissingChecksumField(_)));
+        }
+
+        // ── from_tag_values: field-level parsing (runs AFTER framing+checksum,
+        //    so we exercise it directly) ─────────────────────────────────────
+
+        #[test]
+        fn test_from_tag_values_missing_equals() {
+            // WHY: a field with no `=` (`FOO\x01`) is unparseable. Structured
+            // error, no panic.
+            let raw = b"35=0\x01FOO\x0149=A\x01";
+            let err = FixMessage::from_tag_values(raw).expect_err("missing '=' in a field");
+            assert!(matches!(err, FixError::Parse(_)));
+        }
+
+        #[test]
+        fn test_from_tag_values_non_numeric_tag() {
+            // WHY: tags are integers; `abc=1` can't index anything. Structured
+            // error, no panic.
+            let raw = b"35=0\x01abc=1\x01";
+            let err = FixMessage::from_tag_values(raw).expect_err("non-numeric tag");
+            assert!(matches!(err, FixError::Parse(_)));
+        }
+
+        #[test]
+        fn test_from_tag_values_invalid_utf8() {
+            // WHY: FIX is byte-oriented; a value with invalid UTF-8 must not
+            // crash the parser. (Tightening this to byte-slice fields instead
+            // of `str` is a possible future change, but today it must at least
+            // be a graceful error.)
+            let raw = b"35=0\x0158=\xFF\xFE\x01";
+            let err = FixMessage::from_tag_values(raw).expect_err("invalid UTF-8 body");
+            assert!(matches!(err, FixError::Parse(_)));
+        }
+
+        // ── Semantic vs wire validation ────────────────────────────────────
+
+        #[test]
+        fn test_missing_msgtype_field_parses_as_unknown() {
+            // WHY: a frame with valid framing + checksum but no tag 35 is
+            // *well-formed on the wire* — the parser should accept it and
+            // report `MsgType::Unknown`. Rejecting it here would conflate two
+            // layers: wire parsing (this crate) vs. session/business rules
+            // ("this MsgType is required"), which belong upstream in
+            // `session.rs` / the OMS. This test pins the current behavior so a
+            // future change to it is deliberate.
+            let frame = build_raw_frame("FIX.4.4", &[(49, "A"), (56, "B"), (34, "1")]);
+            let mut parser = FixParser::new();
+            parser.push_bytes(&frame);
+            let msg = parser
+                .next_message()
+                .expect("frame is well-formed on the wire")
+                .expect("frame is complete");
+            assert_eq!(
+                msg.msg_type(),
+                MsgType::Unknown,
+                "no tag 35 => Unknown; semantic 'MsgType required' is a separate layer"
+            );
+            assert!(
+                msg.get_field(35).is_none(),
+                "this frame genuinely carries no MsgType field"
+            );
+        }
+
+        // ── Flagged limitations (documented, not fixed in this PR) ──────────
+
+        #[test]
+        fn test_soh_inside_length_delimited_data_field_is_lossy() {
+            // LIMITATION: FIX length-delimited data fields — tag 95 RawDataLength
+            // immediately followed by tag 96 RawData — may legally contain raw
+            // `\x01` bytes inside the RawData value. This parser splits the body
+            // *naively* on `\x01` and does not honor the length prefix, so an
+            // embedded SOH is misread as a field separator and the data field is
+            // truncated/garbled. This test documents the current (lossy) behavior;
+            // honoring length-delimited fields (95→96, and the other
+            // Length/Data pairs) is follow-up work, intentionally out of scope
+            // for this PR.
+            //
+            // Frame: 95=4\x0196=A\x01BC\x01  — RawDataLength says 4 bytes
+            // ("A\x01BC"), but the naive splitter sees `96=A`, then a stray
+            // `BC` chunk with no `=`.
+            let raw = b"35=0\x0149=S\x0156=T\x0134=1\x0195=4\x0196=A\x01BC\x01";
+            let result = FixMessage::from_tag_values(raw);
+            // Today: the `BC\x01` fragment has no `=` → parse error. We assert
+            // it so a future fix that *correctly* handles length-delimited data
+            // (and thus makes this `Ok`) trips this test on purpose.
+            assert!(
+                result.is_err(),
+                "naive SOH-splitting currently mishandles length-delimited data fields"
+            );
+        }
+
+        #[test]
+        fn test_checksum_collision_is_accepted() {
+            // LIMITATION: FIX's CheckSum (tag 10) is the sum of all preceding
+            // bytes mod 256 — a *transmission-integrity* check, not tamper
+            // detection. Two different bodies can share the same mod-256 sum, so
+            // a payload mutated in a sum-preserving way (e.g. swap one byte +1
+            // and another -1) sails through. The parser accepts it; surfacing
+            // (not "fixing") this is the point. Real tamper resistance would
+            // need a MAC/signature layer above FIX, which is out of scope.
+            let original =
+                build_fix_message(&[(8, "FIX.4.4"), (35, "0"), (49, "AB"), (56, "CD"), (34, "1")]);
+            // Find the two-byte sender comp id "AB" inside the body and turn it
+            // into "BA" (same byte multiset → same sum → checksum still valid).
+            let s = std::str::from_utf8(&original).unwrap();
+            let pos = s.find("49=AB").map(|i| i + 3).unwrap();
+            let mut mutated = original.clone();
+            mutated[pos] = b'B';
+            mutated[pos + 1] = b'A';
+            assert_ne!(original, mutated, "we actually changed the bytes");
+
+            let mut parser = FixParser::new();
+            parser.push_bytes(&mutated);
+            let msg = parser
+                .next_message()
+                .expect("mod-256 sum still matches, so the parser accepts it")
+                .expect("frame is complete");
+            // The mutation went through undetected — that's the documented gap.
+            assert_eq!(msg.get_field(49).map(|s| s.as_str()), Some("BA"));
         }
     }
 }

--- a/crates/fix/src/session.rs
+++ b/crates/fix/src/session.rs
@@ -145,8 +145,19 @@ impl FixSession {
                                     Ok(n) => {
                                         last_rx = Instant::now();
                                         parser.push_bytes(&read_buf[..n]);
-                                        while let Some(msg) = parser.next_message() {
-                                            self.handle_inbound(msg, &mut writer).await?;
+                                        loop {
+                                            match parser.next_message() {
+                                                Ok(Some(msg)) => self.handle_inbound(msg, &mut writer).await?,
+                                                // Not enough bytes yet — wait for the next read.
+                                                Ok(None) => break,
+                                                // One frame was garbage. The parser has already
+                                                // resynced past it; log and keep draining. We do
+                                                // NOT propagate this — a single malformed frame
+                                                // must not tear down the session (recover-open).
+                                                // A genuine I/O error is handled by the `Err(e)`
+                                                // arm on `reader.read` above, not here.
+                                                Err(e) => warn!("FIX: dropped malformed frame, resynced: {e}"),
+                                            }
                                         }
                                     }
                                     Err(e) => {


### PR DESCRIPTION
## What

`FixParser::next_message()` returns `Result<Option<FixMessage>, FixError>` instead of `Option<FixMessage>`, so the three outcomes that were collapsed into `None` are now distinguishable in the type:

- `Ok(Some(msg))` — a complete, checksum-valid message was parsed and consumed.
- `Ok(None)` — not enough bytes yet; the buffer is left untouched. (Includes the case where tag 9's `BodyLength` claims more bytes than are currently buffered — that's *incomplete*, not malformed.)
- `Err(FixError::…)` — the frame at the current `8=` is malformed (bad `BodyLength` framing, missing or non-numeric `CheckSum` field, checksum mismatch). Before returning, the parser **resynchronizes** past exactly that frame.

Closes #43.

## Why

`next_message() -> Option<FixMessage>` conflated three different conditions: "wait for more bytes", "this frame is garbage", and "field-level parse failure". The worst failure mode: on a malformed frame the parser would `drain` the whole buffer and return `None`, **silently discarding any valid messages that followed the bad one in the same TCP read** — a stream-desync / silent-data-loss hazard in an OMS↔exchange path, exactly the class of bug that's a nightmare to diagnose in a live session.

## The recover-open invariant

A single malformed frame is a *local* event, never a connection-level one. On `Err`, the parser advances past the corrupt frame and scans forward to the next `8=` that follows a `SOH` (or buffer start), discarding only the corrupt frame; a valid message behind it is returned by the very next call. If no further `8=` exists, the buffer is drained. In `session.rs` the inbound-read loop logs the `Err` and continues — it does **not** propagate, so one bad frame can't kill the FIX session. Genuine I/O errors are still handled separately and do break the read loop.

## Test matrix (added to `crates/fix/src/lib.rs`)

| case | expected |
|---|---|
| `BodyLength` under-counts (`10=` before declared end) | `Err(BodyLengthFraming)`; next valid frame still returned |
| `BodyLength` over-counts (lands inside a field) | `Err(BodyLengthFraming)` + resync |
| `BodyLength` > buffered bytes | `Ok(None)`, buffer preserved (incomplete, **not** an error) |
| checksum value wrong | `Err(ChecksumMismatch)` + resync recovers next frame |
| non-numeric checksum (`10=ABC`) | `Err(MissingChecksumField)` |
| truncated mid-frame, then completed | `Ok(None)` → `Ok(Some(..))` |
| `from_tag_values`: missing `=`, non-numeric tag, invalid UTF-8 | structured `FixError::Parse`, no panic |
| wire-valid frame with no tag 35 | parses; `msg_type() == Unknown` (semantic validation is a separate layer) |

All pre-existing tests updated for the new return type. `cargo test -p fix` → 18 passed / 0 failed; `cargo clippy -p fix --all-targets` clean.

> Note: this PR also adds the `macros` feature to the crate's `tokio` dependency — it's required for `tokio::select!` in `session.rs`, and `cargo test -p fix` doesn't build standalone without it (the workspace-level `tokio = { features = ["full"] }` masks this when building the full workspace). Happy to split that into its own commit if you'd prefer.

## Out of scope / follow-up (flagged with documenting tests, not fixed here)

- **Length-delimited data fields** — FIX tag-95 `RawDataLength` → tag-96 `RawData` pairs may legally contain raw `\x01`; the parser splits the body naively on `\x01` and ignores the length prefix, so an embedded `SOH` garbles the data field. `test_soh_inside_length_delimited_data_field_is_lossy` documents the current behavior. Honoring length-delimited fields is a separate change.
- **Checksum collisions** — FIX's mod-256 `CheckSum` is a transmission-integrity check, not tamper detection; a sum-preserving mutation passes. `test_checksum_collision_is_accepted` surfaces this. Real tamper resistance needs a MAC/signature layer above FIX.
